### PR TITLE
Fix mcat install

### DIFF
--- a/bucket/mcat.json
+++ b/bucket/mcat.json
@@ -9,6 +9,7 @@
             "hash": "4175f254f4892a2993d78ae973b5b24d97fe171fc51a3ce801f28efc1421c375"
         }
     },
+    "extract_dir": "mcat-x86_64-pc-windows-msvc",
     "bin": "mcat.exe",
     "checkver": "github",
     "autoupdate": {

--- a/bucket/mcat.json
+++ b/bucket/mcat.json
@@ -6,10 +6,10 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/Skardyy/mcat/releases/download/v0.5.6/mcat-x86_64-pc-windows-msvc.zip",
-            "hash": "4175f254f4892a2993d78ae973b5b24d97fe171fc51a3ce801f28efc1421c375"
+            "hash": "4175f254f4892a2993d78ae973b5b24d97fe171fc51a3ce801f28efc1421c375",
+            "extract_dir": "mcat-x86_64-pc-windows-msvc"
         }
     },
-    "extract_dir": "mcat-x86_64-pc-windows-msvc",
     "bin": "mcat.exe",
     "checkver": "github",
     "autoupdate": {


### PR DESCRIPTION
The structure of the release has changed and it now includes a subdirectory that matches the build target.

https://github.com/Skardyy/mcat/releases/download/v0.5.2/mcat-x86_64-pc-windows-msvc.zip